### PR TITLE
Dragging image causes redirect in Firefox

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -107,6 +107,7 @@ var Droppable = Ember.Mixin.create({
     this._resetDroppability();
     // TODO: might not need this? I can't remember why its here
     event.stopPropagation();
+    event.preventDefault();
     return false;
   }.on('drop'),
 


### PR DESCRIPTION
Dragging an image causes the user to be redirected to the image URL in Firefox.
